### PR TITLE
Fixes for bookmarks :)

### DIFF
--- a/mobile/Features/ContentLibrary/Components/RecommendationCard.jsx
+++ b/mobile/Features/ContentLibrary/Components/RecommendationCard.jsx
@@ -28,7 +28,7 @@ export default function RecommendationCard({
 
   /* Adds Tag to Users Favorites List */
   const favoriteTag = async () => {
-    const res = await axios.post(`${process.env.EXPO_PUBLIC_SERVER_URL}/offUser/favoriteTag`, { tagName, id }, { headers: authHeader });
+    const res = await axios.post(`${process.env.EXPO_PUBLIC_SERVER_URL}/offUser/favoriteTag`, { tag: tagName, id }, { headers: authHeader });
     if (res.status === 200) {
       addFavorite(tagName);
     }
@@ -36,7 +36,7 @@ export default function RecommendationCard({
 
   // /* Remove Tag from Users Favorites List */
   const unfavoriteTag = async () => {
-    const res = await axios.post(`${process.env.EXPO_PUBLIC_SERVER_URL}/offUser/unfavoriteTag`, { tagName, id }, { headers: authHeader });
+    const res = await axios.post(`${process.env.EXPO_PUBLIC_SERVER_URL}/offUser/unfavoriteTag`, { tag: tagName, id }, { headers: authHeader });
     if (res.status === 200) {
       deleteFavorite(tagName);
     }

--- a/mobile/Features/ContentLibrary/Screens/ContentLibrary.jsx
+++ b/mobile/Features/ContentLibrary/Screens/ContentLibrary.jsx
@@ -37,7 +37,7 @@ export default function ContentLibrary({ navigation }) {
 
   const navigateToResourceList = (subtopicName, tagName) => {
     // navigation.navigate('Resource List', { subtopicName, routeName: 'Content Library' });
-    navigation.navigate('Resource List', { subtopicName, tagName, routeName: 'Content Library' });
+    navigation.navigate('Resource List', { subtopicName, tagName, route: 'Content Library' });
     // const navigateToResourceList = (subtopicName) => {
     //   navigation.navigate('Resource List', { subtopicName, tagName });
     // };

--- a/mobile/Features/ContentLibrary/Screens/ResourceList.jsx
+++ b/mobile/Features/ContentLibrary/Screens/ResourceList.jsx
@@ -78,10 +78,11 @@ function ResourceList({ navigation }) {
       navigation.navigate('FolderContent', {
         folderName, folderDescription, resources: folderResources, tags: folderTags,
       }); // set index to 0 as default for now
-    } else if (prevRoute === 'FolderContent'){
+    } else if (prevRoute === 'Content Library') {
+      navigation.navigate('Content Library'); // set index to 0 as default for now
+    }
+    else {
       navigation.navigate('Tag', { index: 0, routeName: 'Content Library', tagName }); // set index to 0 as default for now
-    } else {
-      navigation.navigate('Content Library');
     }
   };
   const navigateToResource = (resourceName, authorName, content, tags) => {
@@ -163,8 +164,13 @@ function ResourceList({ navigation }) {
     getFolders();
   }, [modalVisibleCreated]);
   useEffect(() => {
-    getFavorites();
-  }, []);
+    const unsubscribe = navigation.addListener('focus', () => {
+      getFavorites();
+    });
+  
+    // Cleanup the listener when the component unmounts
+    return unsubscribe;
+  }, [navigation]);
 
   return (
     <View

--- a/mobile/Features/ContentLibrary/Screens/Tag.jsx
+++ b/mobile/Features/ContentLibrary/Screens/Tag.jsx
@@ -98,8 +98,13 @@ export default function Tag({ navigation, route }) {
     getFolders();
   }, [modalVisibleCreated]);
   useEffect(() => {
-    getFavorites();
-  }, []);
+    const unsubscribe = navigation.addListener('focus', () => {
+      getFavorites();
+    });
+  
+    // Cleanup the listener when the component unmounts
+    return unsubscribe;
+  }, [navigation]);
 
   return (
     <ScrollView

--- a/server/controllers/offUserController.js
+++ b/server/controllers/offUserController.js
@@ -167,19 +167,22 @@ const getFavorites = async (req, res) => {
 
 const favoriteTag = async (req, res) => {
   console.log('favorite tag');
-  const { tagName, id } = req.body;
+  const { id, tag } = req.body;
   try {
     const user = await User.findById(id);
     if (!user) {
       return res.status(404).send({ message: 'User not found' });
     }
-    if (!user.favoritedTags.includes(tagName)) user.favoritedTags.push(tagName);
+
+    if (!user.favoritedTags.includes(tag)) user.favoritedTags.push(tag);
+    console.log(tag);
+    console.log(user.favoritedTags);
     // if (!user.favoritedTags.has(tag)) {
     //   user.favoritedTags.set(tag, { folders: [] });
     // }
     await user.save();
 
-    return res.status(200).send(user.favoritedTags);
+    return res.send(user.favoritedTags);
   } catch (err) {
     console.error(err);
     return res.status(500).send(err);
@@ -191,16 +194,16 @@ function sanitize(name) {
 }
 const unfavoriteTag = async (req, res) => {
   console.log('unfavorite tag');
-  const { tagName, id } = req.body;
+  const { id, tag } = req.body;
   try {
     const user = await User.findById(id);
     if (!user) {
       return res.status(404).send({ message: 'User not found' });
     }
-    user.favoritedTags = user.favoritedTags.filter((t) => t !== tagName);
+    user.favoritedTags = user.favoritedTags.filter((t) => t !== tag);
 
     // also remove from all favoritedFolders it is in
-    const sanitizedTag = sanitize(tagName);
+    const sanitizedTag = sanitize(tag);
 
     const folderNames = user.tagToFolders.get(sanitizedTag);
 
@@ -208,7 +211,7 @@ const unfavoriteTag = async (req, res) => {
     if (folderNames) {
       folderNames.forEach((folderName) => {
         const newTags = user.favoritedFolders.get(folderName).tags.filter(
-          (t) => t !== tagName,
+          (t) => t !== tag,
         );
         user.favoritedFolders.get(folderName).tags = newTags;
       });
@@ -221,7 +224,7 @@ const unfavoriteTag = async (req, res) => {
 
     await user.save();
 
-    return res.status(200).send(user.favoritedTags);
+    return res.send(user.favoritedTags);
   } catch (err) {
     console.error(err);
     return res.status(500).send(err);


### PR DESCRIPTION
- Fixing favoriting/unfavoriting of tags (incosistent use of `tag` vs `tagName` when calling the controller functions, changed it to use `tag`)
- Navigation from resource list back to tags (previously, clicking the back button for Resource Lists takes you back to the Content Library)

Notes for next steps:

Content Library Recommended Section: favorited tags (bookmarked icons) don’t refresh after clicking on the tag, favoriting it from the upper right corner, and going back (might have to do event listener like I did in `Tag.jsx `and `Resource.jsx`)
- Also, clicking the bookmark icon doesn’t trigger the modal popups that allow you to add the tag to a folder
- If we don’t have time could we just get rid of the bookmarked icon for these recommended cards

Also, the render the images for Tag.jsx
